### PR TITLE
On 1458 ping endpoint

### DIFF
--- a/src/SFA.DAS.ApplyService.InternalApi/Controllers/PingController.cs
+++ b/src/SFA.DAS.ApplyService.InternalApi/Controllers/PingController.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace SFA.DAS.ApplyService.InternalApi.Controllers
+{
+    public class PingController : Controller
+    {
+        [HttpGet("/Ping")]
+        public IActionResult Ping()
+        {
+            return Ok("Pong");
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.InternalApi/web.config
+++ b/src/SFA.DAS.ApplyService.InternalApi/web.config
@@ -9,6 +9,17 @@
         <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
       </handlers>
       <aspNetCore processPath="dotnet" arguments=".\SFA.DAS.ApplyService.InternalApi.dll" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" />
+      <rewrite>
+        <rules>
+          <rule name="Rewrite AlwaysOn" stopProcessing="true">
+            <match url="^$" />
+            <conditions>
+              <add input="{HTTP_USER_AGENT}" pattern="^AlwaysOn$" />
+            </conditions>
+            <action type="Rewrite" url="/Ping" />
+          </rule>
+        </rules>
+      </rewrite>
     </system.webServer>
   </location>
 </configuration>

--- a/src/SFA.DAS.ApplyService.Web/Controllers/PingController.cs
+++ b/src/SFA.DAS.ApplyService.Web/Controllers/PingController.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace SFA.DAS.ApplyService.Web.Controllers
+{
+    public class PingController : Controller
+    {
+        [HttpGet("/Ping")]
+        public IActionResult Ping()
+        {
+            return Ok("Pong");
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Web/SFA.DAS.ApplyService.Web.csproj
+++ b/src/SFA.DAS.ApplyService.Web/SFA.DAS.ApplyService.Web.csproj
@@ -27,6 +27,9 @@
     <Content Update="nlog.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Update="inactive_app_offline_private_beta.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SFA.DAS.ApplyService.Application\SFA.DAS.ApplyService.Application.csproj" />

--- a/src/SFA.DAS.ApplyService.Web/web.config
+++ b/src/SFA.DAS.ApplyService.Web/web.config
@@ -9,6 +9,17 @@
                 <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
             </handlers>
             <aspNetCore processPath="dotnet" arguments=".\SFA.DAS.ApplyService.Web.dll" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" />
+            <rewrite>
+                <rules>
+                    <rule name="Rewrite AlwaysOn" stopProcessing="true">
+                        <match url="^$" />
+                        <conditions>
+                            <add input="{HTTP_USER_AGENT}" pattern="^AlwaysOn$" />
+                        </conditions>
+                        <action type="Rewrite" url="/Ping" />
+                    </rule>
+                </rules>
+            </rewrite>
         </system.webServer>
     </location>
 </configuration>


### PR DESCRIPTION
URL Rewrite for anything with a user agent containing "AlwaysOn" to route through to a new /Ping endpoint.  This is to stop Azure's AlwaysOn GETs from leaving errors in our logs.