### PR TITLE
ON-1873 - Upsert security headers

### DIFF
--- a/src/SFA.DAS.ApplyService.InternalApi/Infrastructure/SecurityHeaderExtensions.cs
+++ b/src/SFA.DAS.ApplyService.InternalApi/Infrastructure/SecurityHeaderExtensions.cs
@@ -8,16 +8,16 @@ namespace SFA.DAS.ApplyService.InternalApi.Infrastructure
         {
             app.Use(async (context, next) =>
             {
-                context.Response.Headers.Add("X-Frame-Options", "SAMEORIGIN");
-                context.Response.Headers.Add("X-XSS-Protection", "1; mode=block");
-                context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
-                context.Response.Headers.Add("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self' data:;");
-                context.Response.Headers.Add("Referrer-Policy", "strict-origin");
-                context.Response.Headers.Add("Cache-Control", "no-cache, no-store, must-revalidate");
-                context.Response.Headers.Add("Pragma", "no-cache");
+                context.Response.Headers["X-Frame-Options"] = "SAMEORIGIN";
+                context.Response.Headers["X-XSS-Protection"] = "1; mode=block";
+                context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+                context.Response.Headers["Content-Security-Policy"] = "default-src 'self'; script-src 'self' 'unsafe-inline'; font-src 'self' data:;";
+                context.Response.Headers["Referrer-Policy"] = "strict-origin";
+                context.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+                context.Response.Headers["Pragma"] = "no-cache";
                 await next();
             });
-            
+
             return app;
         }
     }

--- a/src/SFA.DAS.ApplyService.Web/Infrastructure/SecurityHeadersExtensions.cs
+++ b/src/SFA.DAS.ApplyService.Web/Infrastructure/SecurityHeadersExtensions.cs
@@ -8,16 +8,16 @@ namespace SFA.DAS.ApplyService.Web.Infrastructure
         {
             app.Use(async (context, next) =>
             {
-                context.Response.Headers.Add("X-Frame-Options", "SAMEORIGIN");
-                context.Response.Headers.Add("X-XSS-Protection", "1; mode=block");
-                context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
-                context.Response.Headers.Add("Content-Security-Policy", "default-src 'self'; img-src 'self' *.google-analytics.com; script-src 'self' 'unsafe-inline' *.googletagmanager.com *.postcodeanywhere.co.uk *.google-analytics.com *.googleapis.com; font-src 'self' data:;");
-                context.Response.Headers.Add("Referrer-Policy", "strict-origin");
-                context.Response.Headers.Add("Cache-Control", "no-cache, no-store, must-revalidate");
-                context.Response.Headers.Add("Pragma", "no-cache");
+                context.Response.Headers["X-Frame-Options"] = "SAMEORIGIN";
+                context.Response.Headers["X-XSS-Protection"] = "1; mode=block";
+                context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+                context.Response.Headers["Content-Security-Policy"] = "default-src 'self'; img-src 'self' *.google-analytics.com; script-src 'self' 'unsafe-inline' *.googletagmanager.com *.postcodeanywhere.co.uk *.google-analytics.com *.googleapis.com; font-src 'self' data:;";
+                context.Response.Headers["Referrer-Policy"] = "strict-origin";
+                context.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+                context.Response.Headers["Pragma"] = "no-cache";
                 await next();
             });
-            
+
             return app;
         }
     }


### PR DESCRIPTION
This change allows upserting of headers.
Previously if the header exists (perhaps injected via WAF) then it would rightly throw an exception which is not the intention here.