### PR TITLE
On 1793 action feedback before submitting

### DIFF
--- a/src/SFA.DAS.ApplyService.Application.UnitTests/Handlers/UpdatePageAnswersHandlerTests/UpdatePageAnswersHandlerTestBase.cs
+++ b/src/SFA.DAS.ApplyService.Application.UnitTests/Handlers/UpdatePageAnswersHandlerTests/UpdatePageAnswersHandlerTestBase.cs
@@ -27,7 +27,6 @@ namespace SFA.DAS.ApplyService.Application.UnitTests.Handlers.UpdatePageAnswersH
         protected Answer AnswerQ4;
         protected Answer AnswerQ5;
 
-        protected string SectionStatus;
         protected QnAData QnAData;
 
         [SetUp]

--- a/src/SFA.DAS.ApplyService.Application.UnitTests/Handlers/UpdatePageAnswersHandlerTests/UpdatePageAnswersHandlerTestBase.cs
+++ b/src/SFA.DAS.ApplyService.Application.UnitTests/Handlers/UpdatePageAnswersHandlerTests/UpdatePageAnswersHandlerTestBase.cs
@@ -27,6 +27,7 @@ namespace SFA.DAS.ApplyService.Application.UnitTests.Handlers.UpdatePageAnswersH
         protected Answer AnswerQ4;
         protected Answer AnswerQ5;
 
+        protected string SectionStatus;
         protected QnAData QnAData;
 
         [SetUp]
@@ -220,6 +221,7 @@ namespace SFA.DAS.ApplyService.Application.UnitTests.Handlers.UpdatePageAnswersH
         ApplyRepository = new Mock<IApplyRepository>();
             ApplyRepository.Setup(r => r.GetSection(ApplicationId, 1, 1, UserId)).ReturnsAsync(new ApplicationSection()
             {
+                Status = ApplicationSectionStatus.Draft,
                 QnAData = QnAData
             });
               

--- a/src/SFA.DAS.ApplyService.Application.UnitTests/Handlers/UpdatePageAnswersHandlerTests/When_all_requested_feedback_is_completed.cs
+++ b/src/SFA.DAS.ApplyService.Application.UnitTests/Handlers/UpdatePageAnswersHandlerTests/When_all_requested_feedback_is_completed.cs
@@ -17,6 +17,7 @@ namespace SFA.DAS.ApplyService.Application.UnitTests.Handlers.UpdatePageAnswersH
             // the QnAData is replaced for these tests
             ApplyRepository.Setup(r => r.GetSection(ApplicationId, 1, 1, UserId)).ReturnsAsync(new ApplicationSection()
             {
+                Status = ApplicationSectionStatus.Evaluated,
                 QnAData = new QnAData()
                 {
                     Pages = new List<Page>

--- a/src/SFA.DAS.ApplyService.Application.UnitTests/Handlers/UpdatePageAnswersHandlerTests/When_all_requested_feedback_is_not_completed.cs
+++ b/src/SFA.DAS.ApplyService.Application.UnitTests/Handlers/UpdatePageAnswersHandlerTests/When_all_requested_feedback_is_not_completed.cs
@@ -16,6 +16,7 @@ namespace SFA.DAS.ApplyService.Application.UnitTests.Handlers.UpdatePageAnswersH
 
             ApplyRepository.Setup(r => r.GetSection(ApplicationId, 1, 1, UserId)).ReturnsAsync(new ApplicationSection()
             {
+                Status = ApplicationSectionStatus.Evaluated,
                 QnAData = new QnAData()
                 {
                     Pages = new List<Page>

--- a/src/SFA.DAS.ApplyService.Application.UnitTests/Handlers/UpdatePageAnswersHandlerTests/When_answer_value_not_changed.cs
+++ b/src/SFA.DAS.ApplyService.Application.UnitTests/Handlers/UpdatePageAnswersHandlerTests/When_answer_value_not_changed.cs
@@ -16,13 +16,12 @@ namespace SFA.DAS.ApplyService.Application.UnitTests.Handlers.UpdatePageAnswersH
         [Test]
         public void Then_validation_succeeds_if_application_is_still_in_draft()
         {
-            SectionStatus = ApplicationSectionStatus.Draft;
             AnswerQ1 = new Answer() { QuestionId = "Q1", Value = "Yes" };
             AnswerQ1Dot1 = new Answer() { QuestionId = "Q1.1", Value = "SomeAnswer" };
 
             ApplyRepository.Setup(r => r.GetSection(ApplicationId, 1, 1, UserId)).ReturnsAsync(new ApplicationSection()
             {
-                Status = SectionStatus,
+                Status = ApplicationSectionStatus.Draft,
                 QnAData = QnAData
             });
 
@@ -58,13 +57,12 @@ namespace SFA.DAS.ApplyService.Application.UnitTests.Handlers.UpdatePageAnswersH
         [Test]
         public void Then_validation_fail_if_application_is_not_still_in_draft()
         {
-            SectionStatus = ApplicationSectionStatus.Evaluated;
             AnswerQ1 = new Answer() { QuestionId = "Q1", Value = "Yes" };
             AnswerQ1Dot1 = new Answer() { QuestionId = "Q1.1", Value = "SomeAnswer" };
 
             ApplyRepository.Setup(r => r.GetSection(ApplicationId, 1, 1, UserId)).ReturnsAsync(new ApplicationSection()
             {
-                Status = SectionStatus,
+                Status = ApplicationSectionStatus.Evaluated,
                 QnAData = QnAData
             });
 

--- a/src/SFA.DAS.ApplyService.Application.UnitTests/Handlers/UpdatePageAnswersHandlerTests/When_no_answers_on_multiple_answers_page_with_existing_answers_are_provided.cs
+++ b/src/SFA.DAS.ApplyService.Application.UnitTests/Handlers/UpdatePageAnswersHandlerTests/When_no_answers_on_multiple_answers_page_with_existing_answers_are_provided.cs
@@ -49,7 +49,7 @@ namespace SFA.DAS.ApplyService.Application.UnitTests.Handlers.UpdatePageAnswersH
         }
 
         [Test]
-        public void Then_section_is_not_saved()
+        public void Then_section_is_not_saved_with_the_new_answers()
         {
             Handler.Handle(new UpdatePageAnswersRequest(ApplicationId, UserId, 1, 1, "3", 
                 new List<Answer>()
@@ -70,11 +70,32 @@ namespace SFA.DAS.ApplyService.Application.UnitTests.Handlers.UpdatePageAnswersH
                     section.QnAData.Pages.First(p => p.PageId == "3").PageOfAnswers[0].Answers[1].Value == AnswerQ5.Value), UserId), Times.Never());
         }
 
+        [Test]
+        public void Then_section_is_saved_with_the_existing_answers()
+        {
+            Handler.Handle(new UpdatePageAnswersRequest(ApplicationId, UserId, 1, 1, "3",
+                new List<Answer>()
+                {
+                    AnswerQ4,
+                    AnswerQ5
+                },
+                false), new CancellationToken()).Wait();
+
+            ApplyRepository.Verify(r => r.SaveSection(It.Is<ApplicationSection>(
+                section =>
+                    section.QnAData.Pages.First(p => p.PageId == "3").PageOfAnswers[0].Answers[0].QuestionId == _existingAnswerQ4.QuestionId &&
+                    section.QnAData.Pages.First(p => p.PageId == "3").PageOfAnswers[0].Answers[0].Value == _existingAnswerQ4.Value), UserId), Times.Once());
+
+            ApplyRepository.Verify(r => r.SaveSection(It.Is<ApplicationSection>(
+                section =>
+                    section.QnAData.Pages.First(p => p.PageId == "3").PageOfAnswers[0].Answers[1].QuestionId == _existingAnswerQ5.QuestionId &&
+                    section.QnAData.Pages.First(p => p.PageId == "3").PageOfAnswers[0].Answers[1].Value == _existingAnswerQ5.Value), UserId), Times.Once());
+        }
 
         [Test]
-        public void Then_page_is_returned_with_validation_errors()
+        public void Then_page_is_returned_with_correct_next_page()
         {
-            var result = Handler.Handle(new UpdatePageAnswersRequest(ApplicationId, UserId, 1, 1, "3", 
+            var result = Handler.Handle(new UpdatePageAnswersRequest(ApplicationId, UserId, 1, 1, "3",
                 new List<Answer>()
                 {
                     AnswerQ4,
@@ -82,9 +103,12 @@ namespace SFA.DAS.ApplyService.Application.UnitTests.Handlers.UpdatePageAnswersH
                 },
                 false), new CancellationToken()).Result;
 
-            result.Page.Next[0].ConditionMet.Should().Be(false);
-            result.ValidationErrors.Should().NotBeEmpty();
-            result.ValidationPassed.Should().BeFalse();
+            result.Page.Next.Should().ContainSingle(p => p.ConditionMet);
+            result.Page.Next[0].Action.Should().Be("NextPage");
+            result.Page.Next[0].ReturnId.Should().Be("4");
+
+            result.ValidationErrors.Should().BeNull();
+            result.ValidationPassed.Should().BeTrue();
         }
 
         [Test]

--- a/src/SFA.DAS.ApplyService.Application/Apply/UpdatePageAnswers/UpdatePageAnswersHandler.cs
+++ b/src/SFA.DAS.ApplyService.Application/Apply/UpdatePageAnswers/UpdatePageAnswersHandler.cs
@@ -100,16 +100,14 @@ namespace SFA.DAS.ApplyService.Application.Apply.UpdatePageAnswers
                 }
             }
 
-            if (!atLeastOneAnswerChanged)
+            if (validationPassed && !atLeastOneAnswerChanged && section.Status == Domain.Entities.ApplicationSectionStatus.Evaluated)
             {
-                validationPassed = false;
                 foreach (var question in page.Questions)
                 {
                     validationErrors.Add(new KeyValuePair<string, string>(question.QuestionId, "Unable to save as you have not updated your answer"));
                 }
             }
-
-            if (validationPassed)
+            else if (validationPassed)
             {
                 if (page.HasFeedback)
                 {


### PR DESCRIPTION
This includes the requirement change which is:

Only show answer not changed error if:
- feedback was requested (aka Evaluated status)
- it's passed validation
- none of the answers have been changed