### PR TITLE
Apr 613 tabular data control

### DIFF
--- a/src/RoatpWorkflow.sql
+++ b/src/RoatpWorkflow.sql
@@ -85,39 +85,14 @@ VALUES
           "QuestionBodyText": "SQ-1-SE-1-APR-PG-1-3",
           "Hint": "SQ-1-SE-1-APR-PG-1-3",
           "Input": {
-            "Type": "ComplexRadio",
-            "Options": [
-              {
-                "Label": "Main provider",
-				"HintText" : "Your organisation can train apprentices for other organisations, its own employees, employees of connected organisations or act as a subcontractor for other main and employer providers.",
-                "Value": "1",
-                "FurtherQuestions": null
-              },
-              {
-                "Label": "Employer provider",
-				"HintText": "Your organisation can train its own employees, employees of connected organisations or act as a subcontractor for other employer or main providers.",
-                "Value": "2",
-                "FurtherQuestions": null
-              },
-			  {
-                "Label": "Supporting provider",
-				"HintText": "Your organisation will act as a subcontractor for main and employer providers to train apprentices up to a maximum of £500,000 per year. If your organisation is new on the register, this will be limited to £100,000 in its first year.",
-                "Value": "3",
-                "FurtherQuestions": null
-              }
-            ],
-            "Validations": [
-              {
-                "Name": "Required",
-                "Value": null,
-                "ErrorMessage": "Choose your organisation''s provider route"
-              }
-            ]
+            "Type": "TabularData",
+            "Value": "",
+            "Validations": []
           },
           "Order": null
         }
       ],
-      "PageOfAnswers": [],
+      "PageOfAnswers": [ {"Answers": [ {"QuestionId": "APR-ORG-01", "Value": "{\"Caption\":\"Caption Text\", \"HeadingTitles\": [ \"Heading 1\", \"Heading 2\" ], DataRows: [ {\"Columns\": [\"Col 1\", \"Col 2\"] }] }" } ]}],
       "Next": [      
         {
           "Action": "NextPage",

--- a/src/SFA.DAS.ApplyService.Domain/Apply/TabularData.cs
+++ b/src/SFA.DAS.ApplyService.Domain/Apply/TabularData.cs
@@ -1,0 +1,17 @@
+﻿
+namespace SFA.DAS.ApplyService.Domain.Apply
+{
+    using System.Collections.Generic;
+    
+    public class TabularData
+    {
+        public string Caption { get; set; }
+        public List<string> HeadingTitles { get; set; }
+        public List<TabularDataRow> DataRows { get; set; }
+    }
+
+    public class TabularDataRow
+    {
+        public List<string> Columns { get; set; }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Web/Views/Application/Pages/Controls/_TabularData.cshtml
+++ b/src/SFA.DAS.ApplyService.Web/Views/Application/Pages/Controls/_TabularData.cshtml
@@ -1,0 +1,48 @@
+@using Newtonsoft.Json
+@using SFA.DAS.ApplyService.Domain.Apply;
+@model SFA.DAS.ApplyService.Web.Controllers.QuestionViewModel
+
+@{
+    var isError = Model.ErrorMessages != null && Model.ErrorMessages.Count > 0 ? "govuk-input--error" : "";
+
+    var tableData = JsonConvert.DeserializeObject<TabularData>(Model.Value);
+}
+
+@if (Model.ErrorMessages!=null && Model.ErrorMessages.Count > 0)
+{
+    foreach (var errorMessage in Model.ErrorMessages)
+    {
+        if (errorMessage.Field == Model.QuestionId)
+        {
+            <span class="govuk-error-message">@errorMessage.ErrorMessage</span>
+        }
+    }
+}
+
+<table class="govuk-table">
+    @if (!String.IsNullOrWhiteSpace(tableData.Caption))
+    {
+        <caption class="govuk-table__caption">
+            @tableData.Caption
+        </caption>
+    }
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+        @foreach (var title in tableData.HeadingTitles)
+        {
+            <th class="govuk-table__header" scope="col">@Html.Raw(title)</th>
+        }
+    </tr>
+    </thead>
+    <tbody class="govuk-table_body">
+    @foreach (var dataRow in tableData.DataRows)
+    {
+        <tr class="govuk-table__row">
+            @foreach (var column in dataRow.Columns)
+            {
+                <td class="govuk-table__cell">@Html.Raw(column)</td>
+            }
+        </tr>
+    }
+    </tbody>
+</table>

--- a/src/SFA.DAS.ApplyService.Web/Views/Application/Pages/Controls/_TabularData.cshtml
+++ b/src/SFA.DAS.ApplyService.Web/Views/Application/Pages/Controls/_TabularData.cshtml
@@ -1,14 +1,13 @@
 @using Newtonsoft.Json
-@using SFA.DAS.ApplyService.Domain.Apply;
-@model SFA.DAS.ApplyService.Web.Controllers.QuestionViewModel
+@model dynamic
 
 @{
     var isError = Model.ErrorMessages != null && Model.ErrorMessages.Count > 0 ? "govuk-input--error" : "";
 
-    var tableData = JsonConvert.DeserializeObject<TabularData>(Model.Value);
+    var tableData = JsonConvert.DeserializeObject<dynamic>(Model.Value);
 }
 
-@if (Model.ErrorMessages!=null && Model.ErrorMessages.Count > 0)
+@if (Model.ErrorMessages !=null && Model.ErrorMessages.Count > 0)
 {
     foreach (var errorMessage in Model.ErrorMessages)
     {
@@ -20,7 +19,7 @@
 }
 
 <table class="govuk-table">
-    @if (!String.IsNullOrWhiteSpace(tableData.Caption))
+    @if (tableData.Caption != null)
     {
         <caption class="govuk-table__caption">
             @tableData.Caption


### PR DESCRIPTION
Usage:

Create a question Input node in the QnA data of type "TabularData"

Populate the data for the table by submitting the answer JSON data to the QnA API, as per example:

`{ \"Caption\": \"Here is the caption for the table\", \"HeadingTitles\": [ \"Heading one\", \"Heading two\" ], \"DataRows\": [ { \"Columns\" : [ \"Value 1\", \"Value 2\" ] }, {  \"Columns\" : [ \"Value 3\", \"Value 4\" ]  }  ] }`