### PR TITLE
APR-1003 gateway new applications

### DIFF
--- a/src/SFA.DAS.ApplyService.Application/Review/GetGatewayCounts/GetGatewayCountsHandler.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetGatewayCounts/GetGatewayCountsHandler.cs
@@ -1,0 +1,22 @@
+﻿using MediatR;
+using SFA.DAS.ApplyService.Domain.Review.Gateway;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetGatewayCounts
+{
+    public class GetGatewayCountsHandler : IRequestHandler<GetGatewayCountsRequest, GatewayCounts>
+    {
+        private readonly IReviewRepository _reviewRepository;
+
+        public GetGatewayCountsHandler(IReviewRepository reviewRepository)
+        {
+            _reviewRepository = reviewRepository;
+        }
+
+        public Task<GatewayCounts> Handle(GetGatewayCountsRequest request, CancellationToken cancellationToken)
+        {
+            return _reviewRepository.GetGatewayCountsAsync();
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/GetGatewayCounts/GetGatewayCountsRequest.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetGatewayCounts/GetGatewayCountsRequest.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+using SFA.DAS.ApplyService.Domain.Review.Gateway;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetGatewayCounts
+{
+    public class GetGatewayCountsRequest : IRequest<GatewayCounts>
+    {
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/GetSubmittedApplications/GetSubmittedApplicationsHandler.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetSubmittedApplications/GetSubmittedApplicationsHandler.cs
@@ -1,0 +1,22 @@
+﻿using MediatR;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetSubmittedApplications
+{
+    public class GetSubmittedApplicationsHandler : IRequestHandler<GetSubmittedApplicationsRequest, List<Domain.Entities.Application>>
+    {
+        private readonly IReviewRepository _reviewRepository;
+
+        public GetSubmittedApplicationsHandler(IReviewRepository reviewRepository)
+        {
+            _reviewRepository = reviewRepository;
+        }
+
+        public Task<List<Domain.Entities.Application>> Handle(GetSubmittedApplicationsRequest request, CancellationToken cancellationToken)
+        {
+            return _reviewRepository.GetSubmittedApplicationsAsync();
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/GetSubmittedApplications/GetSubmittedApplicationsRequest.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetSubmittedApplications/GetSubmittedApplicationsRequest.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+using System.Collections.Generic;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetSubmittedApplications
+{
+    public class GetSubmittedApplicationsRequest : IRequest<List<Domain.Entities.Application>>
+    {
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/IReviewRepository.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/IReviewRepository.cs
@@ -1,0 +1,12 @@
+﻿using SFA.DAS.ApplyService.Domain.Review.Gateway;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Application.Review
+{
+    public interface IReviewRepository
+    {
+        Task<List<Domain.Entities.Application>> GetSubmittedApplicationsAsync();
+        Task<GatewayCounts> GetGatewayCountsAsync();
+    }
+}

--- a/src/SFA.DAS.ApplyService.Data/ReviewRepository.cs
+++ b/src/SFA.DAS.ApplyService.Data/ReviewRepository.cs
@@ -1,0 +1,49 @@
+﻿using Dapper;
+using SFA.DAS.ApplyService.Application.Review;
+using SFA.DAS.ApplyService.Configuration;
+using SFA.DAS.ApplyService.Domain.Review.Gateway;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Data
+{
+    public class ReviewRepository : IReviewRepository
+    {
+        private readonly IApplyConfig _config;
+
+        public ReviewRepository(IConfigurationService configurationService)
+        {
+            _config = configurationService.GetConfig().Result;
+        }
+
+        public async Task<List<Domain.Entities.Application>> GetSubmittedApplicationsAsync()
+        {
+            using (var connection = new SqlConnection(_config.SqlConnectionString))
+            {
+                var result = (await connection
+                    .QueryAsync<Domain.Entities.Application>(
+                        @"SELECT * FROM Applications WHERE ApplicationStatus = 'Submitted'"))
+                        .ToList() ;
+
+                return result;
+            }
+        }
+
+        public async Task<GatewayCounts> GetGatewayCountsAsync()
+        {
+            using (var connection = new SqlConnection(_config.SqlConnectionString))
+            {
+                var result = (await connection
+                    .QueryAsync<GatewayCounts>(
+                        @"SELECT 
+	(SELECT Count(*) FROM Applications WHERE ApplicationStatus = 'Submitted') AS NewApplications,
+	(SELECT Count(*) FROM review.Gateway WHERE Status = 'InProgress') AS InProgress"))
+                        .Single();
+
+                return result;
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Database/SFA.DAS.ApplyService.Database.sqlproj
+++ b/src/SFA.DAS.ApplyService.Database/SFA.DAS.ApplyService.Database.sqlproj
@@ -23,6 +23,7 @@
     <SqlServerVerification>False</SqlServerVerification>
     <IncludeCompositeObjects>True</IncludeCompositeObjects>
     <TargetDatabaseSet>True</TargetDatabaseSet>
+    <IncludeSchemaNameInFileName>False</IncludeSchemaNameInFileName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release\</OutputPath>
@@ -60,6 +61,9 @@
     <Folder Include="Tables\" />
     <Folder Include="StoredProcedures" />
     <Folder Include="Sequences" />
+    <Folder Include="review\" />
+    <Folder Include="review\Tables\" />
+    <Folder Include="Security\" />
   </ItemGroup>
   <ItemGroup>
     <Build Include="Tables\Assets.sql" />
@@ -77,11 +81,16 @@
     <Build Include="StoredProcedures\Update_ApplicationSections_QuestionTags.sql" />
     <Build Include="Sequences\AppRefSequence.sql" />
     <Build Include="Tables\ApplicationWorkflow.sql" />
+    <Build Include="review\Tables\Gateway.sql" />
+    <Build Include="Security\review.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Script.PostDeployment1.sql" />
   </ItemGroup>
   <ItemGroup>
     <PreDeploy Include="Script.PreDeployment1.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="SFA.DAS.ApplyService.Database.publish.xml" />
   </ItemGroup>
 </Project>

--- a/src/SFA.DAS.ApplyService.Database/Security/review.sql
+++ b/src/SFA.DAS.ApplyService.Database/Security/review.sql
@@ -1,0 +1,1 @@
+﻿CREATE SCHEMA [review]

--- a/src/SFA.DAS.ApplyService.Database/review/Tables/Gateway.sql
+++ b/src/SFA.DAS.ApplyService.Database/review/Tables/Gateway.sql
@@ -1,0 +1,23 @@
+﻿CREATE TABLE [review].[Gateway](
+	[Id] [uniqueidentifier] NOT NULL,
+	[ApplicationId] [uniqueidentifier] NOT NULL,
+	[Status] [nvarchar](20) NOT NULL,
+ CONSTRAINT [PK_Gateway] PRIMARY KEY CLUSTERED 
+(
+	[Id] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+ALTER TABLE [review].[Gateway]  WITH CHECK ADD  CONSTRAINT [FK_Gateway_Applications] FOREIGN KEY([ApplicationId])
+REFERENCES [dbo].[Applications] ([Id])
+GO
+
+ALTER TABLE [review].[Gateway] CHECK CONSTRAINT [FK_Gateway_Applications]
+GO
+
+
+GO
+CREATE UNIQUE NONCLUSTERED INDEX [IX_Gateway] ON [review].[Gateway]
+(
+	[ApplicationId] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]

--- a/src/SFA.DAS.ApplyService.Domain/Entities/Review/Gateway.cs
+++ b/src/SFA.DAS.ApplyService.Domain/Entities/Review/Gateway.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace SFA.DAS.ApplyService.Domain.Entities.Review
+{
+    public class Gateway
+    {
+        public Guid Id { get; set; }
+        public Guid ApplicationId { get; set; }
+        public string Status { get; set; }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Domain/Review/Gateway/GatewayCounts.cs
+++ b/src/SFA.DAS.ApplyService.Domain/Review/Gateway/GatewayCounts.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.ApplyService.Domain.Review.Gateway
+{
+    public class GatewayCounts
+    {
+        public int NewApplications { get; set; }
+        public int InProgress { get; set; }
+    }
+}

--- a/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpAssessorController.cs
+++ b/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpAssessorController.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.ApplyService.Application.Review.GetGatewayCounts;
+using SFA.DAS.ApplyService.Application.Review.GetSubmittedApplications;
+using SFA.DAS.ApplyService.Domain.Review.Gateway;
+
+namespace SFA.DAS.ApplyService.InternalApi.Controllers
+{
+    [Authorize]
+    [Route("roatp-assessor")]
+    public class RoatpAssessorController : Controller
+    {
+        private readonly IMediator _mediator;
+
+        public RoatpAssessorController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet("applications/submitted")]
+        public async Task<ActionResult<List<Domain.Entities.Application>>> GetSubmittedApplications(Guid applicationId, string questionIdentifier)
+        {
+            return await _mediator.Send(new GetSubmittedApplicationsRequest());
+        }
+
+        [HttpGet("gateway/counts")]
+        public async Task<ActionResult<GatewayCounts>> GetGatewayCounts(Guid applicationId, string questionIdentifier)
+        {
+            return await _mediator.Send(new GetGatewayCountsRequest());
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.InternalApi/Startup.cs
+++ b/src/SFA.DAS.ApplyService.InternalApi/Startup.cs
@@ -29,6 +29,7 @@ using SFA.DAS.ApplyService.InternalApi.Infrastructure;
 
 namespace SFA.DAS.ApplyService.InternalApi
 {
+    using SFA.DAS.ApplyService.Application.Review;
     using UKRLP;
     using static UKRLP.ProviderQueryPortTypeClient;
 
@@ -193,6 +194,7 @@ namespace SFA.DAS.ApplyService.InternalApi
             services.AddTransient<IOrganisationRepository,OrganisationRepository>();
             services.AddTransient<IDfeSignInService,DfeSignInService>();
             services.AddTransient<IGetAnswersService, GetAnswersService>();
+            services.AddTransient<IReviewRepository, ReviewRepository>();
 
             services.AddTransient<IEmailService, EmailService.EmailService>();
             services.AddTransient<IEmailTemplateRepository, EmailTemplateRepository>();

--- a/src/SFA.DAS.ApplyService.InternalApi/appsettings.json
+++ b/src/SFA.DAS.ApplyService.InternalApi/appsettings.json
@@ -9,7 +9,7 @@
   },
   "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",
   "ConnectionStrings": {
-    "Redis": "localhost:234234234234"
+    "Redis": "localhost:6379"
   },
   "EnvironmentName": "LOCAL"
 }


### PR DESCRIPTION
To support the RoATP assessor work I've created an integration branch off of `APR-submaster` called `APR-677_RoATP_gateway_integration`. I'll keep this branch updated by regularly merging from `APR-submaster`

I've created a new database schema called `review` for the new tables we'll be creating to support RoATP application reviews

I've created a new table called `review.Gateway`. My current thinking is that we'll have a separate table per review type. So one per gateway, pmo, assessor & oversight.  As far as I know there is no crossover between these reviews so makes sense to split them along these lines.

Added 2 new endpoints to the Internal API
- `roatp-assessor/applications/submitted` - returns all the applications that are in `Submitted` state
- `roatp-assessor/gateway/counts` - returns a DTO that contains the number of applications that are `Submitted` and gateway reviews that are `In Progress`

Updated the local Redis port as this always errored on statup for me when debugging locally.