### PR TITLE
APR-1026 Gateway assessment audit trail spike

### DIFF
--- a/src/SFA.DAS.ApplyService.Application/Review/CreateGateway/CreateGatewayHandler.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/CreateGateway/CreateGatewayHandler.cs
@@ -1,0 +1,32 @@
+﻿using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Application.Review.CreateGateway
+{
+    public class CreateGatewayHandler : IRequestHandler<CreateGatewayRequest>
+    {
+        private readonly IReviewRepository _reviewRepository;
+
+        public CreateGatewayHandler(IReviewRepository reviewRepository)
+        {
+            _reviewRepository = reviewRepository;
+        }
+
+        public async Task<Unit> Handle(CreateGatewayRequest request, CancellationToken cancellationToken)
+        {
+            await _reviewRepository.CreateGateway(
+                request.Id,
+                request.ApplicationId,
+                request.Status,
+                request.ApplicationStatus,
+                request.CreatedAt,
+                request.CreatedBy,
+                request.AssignedAt,
+                request.AssignedTo,
+                request.AssignedToName);
+
+            return Unit.Value;
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/CreateGateway/CreateGatewayRequest.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/CreateGateway/CreateGatewayRequest.cs
@@ -1,19 +1,18 @@
-﻿using SFA.DAS.ApplyService.Domain.Review;
+﻿using MediatR;
 using System;
-using System.Collections.Generic;
 
-namespace SFA.DAS.ApplyService.Domain.Entities.Review
+namespace SFA.DAS.ApplyService.Application.Review.CreateGateway
 {
-    public class Gateway
+    public class CreateGatewayRequest : IRequest
     {
         public Guid Id { get; set; }
         public Guid ApplicationId { get; set; }
         public string Status { get; set; }
+        public string ApplicationStatus { get; set; }
         public DateTime CreatedAt { get; set; }
         public string CreatedBy { get; set; }
         public DateTime AssignedAt { get; set; }
         public string AssignedTo { get; set; }
         public string AssignedToName { get; set; }
-        public List<Outcome> Outcomes { get; set; }
     }
 }

--- a/src/SFA.DAS.ApplyService.Application/Review/GetGatewayCounts/GetGatewayCountsHandler.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetGatewayCounts/GetGatewayCountsHandler.cs
@@ -1,0 +1,22 @@
+﻿using MediatR;
+using SFA.DAS.ApplyService.Domain.Review.Gateway;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetGatewayCounts
+{
+    public class GetGatewayCountsHandler : IRequestHandler<GetGatewayCountsRequest, GatewayCounts>
+    {
+        private readonly IReviewRepository _reviewRepository;
+
+        public GetGatewayCountsHandler(IReviewRepository reviewRepository)
+        {
+            _reviewRepository = reviewRepository;
+        }
+
+        public Task<GatewayCounts> Handle(GetGatewayCountsRequest request, CancellationToken cancellationToken)
+        {
+            return _reviewRepository.GetGatewayCountsAsync();
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/GetGatewayCounts/GetGatewayCountsRequest.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetGatewayCounts/GetGatewayCountsRequest.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+using SFA.DAS.ApplyService.Domain.Review.Gateway;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetGatewayCounts
+{
+    public class GetGatewayCountsRequest : IRequest<GatewayCounts>
+    {
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/GetGatewayInProgress/GetGatewayInProgressHandler.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetGatewayInProgress/GetGatewayInProgressHandler.cs
@@ -1,0 +1,23 @@
+﻿using MediatR;
+using SFA.DAS.ApplyService.Domain.Entities.Review;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetGatewayInProgress
+{
+    public class GetGatewayInProgressHandler : IRequestHandler<GetGatewayInProgressRequest, List<Gateway>>
+    {
+        private readonly IReviewRepository _reviewRepository;
+
+        public GetGatewayInProgressHandler(IReviewRepository reviewRepository)
+        {
+            _reviewRepository = reviewRepository;
+        }
+
+        public Task<List<Gateway>> Handle(GetGatewayInProgressRequest request, CancellationToken cancellationToken)
+        {
+            return _reviewRepository.GetGatewayInProgressAsync();
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/GetGatewayInProgress/GetGatewayInProgressRequest.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetGatewayInProgress/GetGatewayInProgressRequest.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+using SFA.DAS.ApplyService.Domain.Entities.Review;
+using System.Collections.Generic;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetGatewayInProgress
+{
+    public class GetGatewayInProgressRequest : IRequest<List<Gateway>>
+    {
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/GetGatewayReview/GetGatewayReviewHandler.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetGatewayReview/GetGatewayReviewHandler.cs
@@ -1,0 +1,22 @@
+﻿using MediatR;
+using SFA.DAS.ApplyService.Domain.Entities.Review;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetGatewayReview
+{
+    public class GetGatewayReviewHandler : IRequestHandler<GetGatewayReviewRequest, Gateway>
+    {
+        private readonly IReviewRepository _reviewRepository;
+
+        public GetGatewayReviewHandler(IReviewRepository reviewRepository)
+        {
+            _reviewRepository = reviewRepository;
+        }
+
+        public Task<Gateway> Handle(GetGatewayReviewRequest request, CancellationToken cancellationToken)
+        {
+            return _reviewRepository.GetGatewayReviewAsync(request.ApplicationId);
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/GetGatewayReview/GetGatewayReviewRequest.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetGatewayReview/GetGatewayReviewRequest.cs
@@ -1,0 +1,16 @@
+﻿using MediatR;
+using SFA.DAS.ApplyService.Domain.Entities.Review;
+using System;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetGatewayReview
+{
+    public class GetGatewayReviewRequest : IRequest<Gateway>
+    {
+        public Guid ApplicationId { get; }
+
+        public GetGatewayReviewRequest(Guid applicationId)
+        {
+            ApplicationId = applicationId;
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/GetRejectedOutcomes/GetRejectedOutcomesHandler.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetRejectedOutcomes/GetRejectedOutcomesHandler.cs
@@ -1,0 +1,36 @@
+﻿using MediatR;
+using SFA.DAS.ApplyService.Domain.Review;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetRejectedOutcomes
+{
+    class GetRejectedOutcomesHandler : IRequestHandler<GetRejectedOutcomesRequest, List<Outcome>>
+    {
+        private readonly IReviewRepository _reviewRepository;
+
+        public GetRejectedOutcomesHandler(IReviewRepository reviewRepository)
+        {
+            _reviewRepository = reviewRepository;
+        }
+
+        public async Task<List<Outcome>> Handle(GetRejectedOutcomesRequest request, CancellationToken cancellationToken)
+        {
+            var gatewayReview = await _reviewRepository.GetGatewayReviewAsync(request.ApplicationId);
+            //todo - maybe we need to concatenate with other reviews (Assessor, PMO, etc...)
+
+            if (gatewayReview.Outcomes == null)
+                return new List<Outcome>();
+
+            var rejectedOutcomes = gatewayReview.Outcomes.Where(o => 
+                o.Result == "Reject" &&
+                o.SectionId == request.SectionId &&
+                o.PageId == request.PageId
+                ).ToList();
+
+            return rejectedOutcomes;
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/GetRejectedOutcomes/GetRejectedOutcomesHandler.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetRejectedOutcomes/GetRejectedOutcomesHandler.cs
@@ -19,7 +19,6 @@ namespace SFA.DAS.ApplyService.Application.Review.GetRejectedOutcomes
         public async Task<List<Outcome>> Handle(GetRejectedOutcomesRequest request, CancellationToken cancellationToken)
         {
             var gatewayReview = await _reviewRepository.GetGatewayReviewAsync(request.ApplicationId);
-            //todo - maybe we need to concatenate with other reviews (Assessor, PMO, etc...)
 
             if (gatewayReview.Outcomes == null)
                 return new List<Outcome>();

--- a/src/SFA.DAS.ApplyService.Application/Review/GetRejectedOutcomes/GetRejectedOutcomesRequest.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetRejectedOutcomes/GetRejectedOutcomesRequest.cs
@@ -1,0 +1,21 @@
+﻿using MediatR;
+using SFA.DAS.ApplyService.Domain.Review;
+using System;
+using System.Collections.Generic;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetRejectedOutcomes
+{
+    public class GetRejectedOutcomesRequest : IRequest<List<Outcome>>
+    {
+        public Guid ApplicationId { get; }
+        public string SectionId { get; }
+        public string PageId { get; }
+
+        public GetRejectedOutcomesRequest(Guid applicationId, string sectionId, string pageId)
+        {
+            ApplicationId = applicationId;
+            SectionId = sectionId;
+            PageId = pageId;
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/GetSubmittedApplications/GetSubmittedApplicationsHandler.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetSubmittedApplications/GetSubmittedApplicationsHandler.cs
@@ -1,0 +1,22 @@
+﻿using MediatR;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetSubmittedApplications
+{
+    public class GetSubmittedApplicationsHandler : IRequestHandler<GetSubmittedApplicationsRequest, List<Domain.Entities.Application>>
+    {
+        private readonly IReviewRepository _reviewRepository;
+
+        public GetSubmittedApplicationsHandler(IReviewRepository reviewRepository)
+        {
+            _reviewRepository = reviewRepository;
+        }
+
+        public Task<List<Domain.Entities.Application>> Handle(GetSubmittedApplicationsRequest request, CancellationToken cancellationToken)
+        {
+            return _reviewRepository.GetSubmittedApplicationsAsync();
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/GetSubmittedApplications/GetSubmittedApplicationsRequest.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/GetSubmittedApplications/GetSubmittedApplicationsRequest.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+using System.Collections.Generic;
+
+namespace SFA.DAS.ApplyService.Application.Review.GetSubmittedApplications
+{
+    public class GetSubmittedApplicationsRequest : IRequest<List<Domain.Entities.Application>>
+    {
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/IReviewRepository.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/IReviewRepository.cs
@@ -11,7 +11,7 @@ namespace SFA.DAS.ApplyService.Application.Review
     {
         Task<List<Domain.Entities.Application>> GetSubmittedApplicationsAsync();
         Task<GatewayCounts> GetGatewayCountsAsync();
-        Task<Gateway> GetGatewayReview(Guid applicationId);
+        Task<Gateway> GetGatewayReviewAsync(Guid applicationId);
         Task UpdateGatewayOutcomesAsync(Guid applicationId, string userId, DateTime changedAt, List<Outcome> outcomesDelta);
 
     }

--- a/src/SFA.DAS.ApplyService.Application/Review/IReviewRepository.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/IReviewRepository.cs
@@ -1,0 +1,12 @@
+﻿using SFA.DAS.ApplyService.Domain.Review.Gateway;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Application.Review
+{
+    public interface IReviewRepository
+    {
+        Task<List<Domain.Entities.Application>> GetSubmittedApplicationsAsync();
+        Task<GatewayCounts> GetGatewayCountsAsync();
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/IReviewRepository.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/IReviewRepository.cs
@@ -1,5 +1,4 @@
-﻿using SFA.DAS.ApplyService.Domain.Entities.Review;
-using SFA.DAS.ApplyService.Domain.Review;
+﻿using SFA.DAS.ApplyService.Domain.Review;
 using SFA.DAS.ApplyService.Domain.Review.Gateway;
 using System;
 using System.Collections.Generic;
@@ -10,9 +9,10 @@ namespace SFA.DAS.ApplyService.Application.Review
     public interface IReviewRepository
     {
         Task<List<Domain.Entities.Application>> GetSubmittedApplicationsAsync();
+        Task CreateGateway(Guid id, Guid applicationId, string status, string applicationStatus, DateTime createdAt, string createdBy, DateTime assignedAt, string assignedTo, string assignedToName);
         Task<GatewayCounts> GetGatewayCountsAsync();
-        Task<Gateway> GetGatewayReviewAsync(Guid applicationId);
+        Task<Domain.Entities.Review.Gateway> GetGatewayReviewAsync(Guid applicationId);
         Task UpdateGatewayOutcomesAsync(Guid applicationId, string userId, DateTime changedAt, List<Outcome> outcomesDelta);
-
+        Task<List<Domain.Entities.Review.Gateway>> GetGatewayInProgressAsync();
     }
 }

--- a/src/SFA.DAS.ApplyService.Application/Review/IReviewRepository.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/IReviewRepository.cs
@@ -1,4 +1,7 @@
-﻿using SFA.DAS.ApplyService.Domain.Review.Gateway;
+﻿using SFA.DAS.ApplyService.Domain.Entities.Review;
+using SFA.DAS.ApplyService.Domain.Review;
+using SFA.DAS.ApplyService.Domain.Review.Gateway;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -8,5 +11,8 @@ namespace SFA.DAS.ApplyService.Application.Review
     {
         Task<List<Domain.Entities.Application>> GetSubmittedApplicationsAsync();
         Task<GatewayCounts> GetGatewayCountsAsync();
+        Task<Gateway> GetGatewayReview(Guid applicationId);
+        Task UpdateGatewayOutcomesAsync(Guid applicationId, string userId, DateTime changedAt, List<Outcome> outcomesDelta);
+
     }
 }

--- a/src/SFA.DAS.ApplyService.Application/Review/UpdateGatewayOutcomes/UpdateGatewayOutcomesCommand.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/UpdateGatewayOutcomes/UpdateGatewayOutcomesCommand.cs
@@ -1,0 +1,15 @@
+﻿using MediatR;
+using SFA.DAS.ApplyService.Domain.Review;
+using System;
+using System.Collections.Generic;
+
+namespace SFA.DAS.ApplyService.Application.Review.UpdateGatewayOutcomes
+{
+    public class UpdateGatewayOutcomesCommand : IRequest
+    {
+        public Guid ApplicationId { get; set; }
+        public string UserId { get; set; }
+        public DateTime ChangedAt { get; set; }
+        public List<Outcome> OutcomesDelta { get; set; }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Application/Review/UpdateGatewayOutcomes/UpdateGatewayOutcomesHandler.cs
+++ b/src/SFA.DAS.ApplyService.Application/Review/UpdateGatewayOutcomes/UpdateGatewayOutcomesHandler.cs
@@ -1,0 +1,27 @@
+﻿using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Application.Review.UpdateGatewayOutcomes
+{
+    public class UpdateGatewayOutcomesHandler : IRequestHandler<UpdateGatewayOutcomesCommand>
+    {
+        private readonly IReviewRepository _reviewRepository;
+
+        public UpdateGatewayOutcomesHandler(IReviewRepository reviewRepository)
+        {
+            _reviewRepository = reviewRepository;
+        }
+
+        public async Task<Unit> Handle(UpdateGatewayOutcomesCommand request, CancellationToken cancellationToken)
+        {
+            await _reviewRepository.UpdateGatewayOutcomesAsync(
+                request.ApplicationId,
+                request.UserId,
+                request.ChangedAt,
+                request.OutcomesDelta);
+
+            return Unit.Value;
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Data/DapperTypeHandlers/GenericTypeHandler.cs
+++ b/src/SFA.DAS.ApplyService.Data/DapperTypeHandlers/GenericTypeHandler.cs
@@ -1,0 +1,19 @@
+﻿using Dapper;
+using Newtonsoft.Json;
+using System.Data;
+
+namespace SFA.DAS.ApplyService.Data.DapperTypeHandlers
+{
+    public class GenericTypeHandler<T> : SqlMapper.TypeHandler<T>
+    {
+        public override T Parse(object value)
+        {
+            return JsonConvert.DeserializeObject<T>(value.ToString());
+        }
+
+        public override void SetValue(IDbDataParameter parameter, T value)
+        {
+            parameter.Value = JsonConvert.SerializeObject(value);
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Data/ReviewRepository.cs
+++ b/src/SFA.DAS.ApplyService.Data/ReviewRepository.cs
@@ -1,8 +1,14 @@
 ﻿using Dapper;
+using Newtonsoft.Json;
 using SFA.DAS.ApplyService.Application.Review;
 using SFA.DAS.ApplyService.Configuration;
+using SFA.DAS.ApplyService.Data.DapperTypeHandlers;
+using SFA.DAS.ApplyService.Domain.Entities.Review;
+using SFA.DAS.ApplyService.Domain.Review;
 using SFA.DAS.ApplyService.Domain.Review.Gateway;
+using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,6 +22,8 @@ namespace SFA.DAS.ApplyService.Data
         public ReviewRepository(IConfigurationService configurationService)
         {
             _config = configurationService.GetConfig().Result;
+
+            SqlMapper.AddTypeHandler(typeof(List<Outcome>), new GenericTypeHandler<List<Outcome>>());
         }
 
         public async Task<List<Domain.Entities.Application>> GetSubmittedApplicationsAsync()
@@ -44,6 +52,65 @@ namespace SFA.DAS.ApplyService.Data
 
                 return result;
             }
+        }
+
+        public async Task<Gateway> GetGatewayReview(Guid applicationId)
+        {
+            using (var connection = new SqlConnection(_config.SqlConnectionString))
+            {
+                var result = (await connection.QueryAsync<Gateway>("SELECT * FROM review.Gateway WHERE ApplicationId = @applicationId",
+                    new { applicationId }))
+                    .SingleOrDefault();
+
+                return result;
+            }
+        }
+
+        public async Task UpdateGatewayOutcomesAsync(Guid applicationId, string userId, DateTime changedAt, List<Outcome> outcomesDelta)
+        {
+            var gatewayReview = await GetGatewayReview(applicationId);
+
+            var outcomes = GetUpdatedOutcomes(gatewayReview.Outcomes, outcomesDelta);
+
+            using (var connection = new SqlConnection(_config.SqlConnectionString))
+            {
+                connection.Open();
+
+                using (IDbTransaction transaction = connection.BeginTransaction())
+                {
+                    await connection.ExecuteAsync("UPDATE review.Gateway SET Outcomes = @outcomes WHERE ApplicationId = @applicationId", new { outcomes, applicationId }, transaction);
+                    await InsertAuditAsync(transaction, nameof(UpdateGatewayOutcomesAsync), applicationId, userId, changedAt, outcomesDelta);
+
+                    transaction.Commit();
+                }
+            }
+        }
+
+        private List<Outcome> GetUpdatedOutcomes(List<Outcome> currentOutcomes, List<Outcome> outcomesDelta)
+        {
+            var updatedOutcomes = currentOutcomes ?? new List<Outcome>();
+
+            foreach (var changedOutcome in outcomesDelta)
+            {
+                updatedOutcomes.RemoveAll(o =>
+                    o.SectionId == changedOutcome.SectionId &&
+                    o.PageId == changedOutcome.PageId &&
+                    o.QuestionId == changedOutcome.QuestionId);
+
+                updatedOutcomes.Add(changedOutcome);
+            }
+
+            return updatedOutcomes;
+        }
+
+        private Task InsertAuditAsync(IDbTransaction transaction, string action, Guid applicationId, string userId, DateTime changedAt, object delta)
+        {
+            var connection = transaction.Connection;
+
+            var changeDelta = JsonConvert.SerializeObject(delta);
+
+            return connection.ExecuteAsync("INSERT INTO review.Audit (Action, ApplicationId, UserId, ChangedAt, ChangeDelta) VALUES (@action, @applicationId, @userId, @changedAt, @changeDelta)",
+                new {action, applicationId, userId, changedAt, changeDelta }, transaction);
         }
     }
 }

--- a/src/SFA.DAS.ApplyService.Data/ReviewRepository.cs
+++ b/src/SFA.DAS.ApplyService.Data/ReviewRepository.cs
@@ -1,0 +1,49 @@
+﻿using Dapper;
+using SFA.DAS.ApplyService.Application.Review;
+using SFA.DAS.ApplyService.Configuration;
+using SFA.DAS.ApplyService.Domain.Review.Gateway;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApplyService.Data
+{
+    public class ReviewRepository : IReviewRepository
+    {
+        private readonly IApplyConfig _config;
+
+        public ReviewRepository(IConfigurationService configurationService)
+        {
+            _config = configurationService.GetConfig().Result;
+        }
+
+        public async Task<List<Domain.Entities.Application>> GetSubmittedApplicationsAsync()
+        {
+            using (var connection = new SqlConnection(_config.SqlConnectionString))
+            {
+                var result = (await connection
+                    .QueryAsync<Domain.Entities.Application>(
+                        @"SELECT * FROM Applications WHERE ApplicationStatus = 'Submitted'"))
+                        .ToList() ;
+
+                return result;
+            }
+        }
+
+        public async Task<GatewayCounts> GetGatewayCountsAsync()
+        {
+            using (var connection = new SqlConnection(_config.SqlConnectionString))
+            {
+                var result = (await connection
+                    .QueryAsync<GatewayCounts>(
+                        @"SELECT 
+	(SELECT Count(*) FROM Applications WHERE ApplicationStatus = 'Submitted') AS NewApplications,
+	(SELECT Count(*) FROM review.Gateway WHERE Status = 'InProgress') AS InProgress"))
+                        .Single();
+
+                return result;
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Data/ReviewRepository.cs
+++ b/src/SFA.DAS.ApplyService.Data/ReviewRepository.cs
@@ -54,7 +54,7 @@ namespace SFA.DAS.ApplyService.Data
             }
         }
 
-        public async Task<Gateway> GetGatewayReview(Guid applicationId)
+        public async Task<Gateway> GetGatewayReviewAsync(Guid applicationId)
         {
             using (var connection = new SqlConnection(_config.SqlConnectionString))
             {
@@ -68,7 +68,7 @@ namespace SFA.DAS.ApplyService.Data
 
         public async Task UpdateGatewayOutcomesAsync(Guid applicationId, string userId, DateTime changedAt, List<Outcome> outcomesDelta)
         {
-            var gatewayReview = await GetGatewayReview(applicationId);
+            var gatewayReview = await GetGatewayReviewAsync(applicationId);
 
             var outcomes = GetUpdatedOutcomes(gatewayReview.Outcomes, outcomesDelta);
 

--- a/src/SFA.DAS.ApplyService.Data/ReviewRepository.cs
+++ b/src/SFA.DAS.ApplyService.Data/ReviewRepository.cs
@@ -107,10 +107,25 @@ namespace SFA.DAS.ApplyService.Data
         {
             var connection = transaction.Connection;
 
-            var changeDelta = JsonConvert.SerializeObject(delta);
+            var dataType = GetAuditDataTypeName(delta);
+            var data = JsonConvert.SerializeObject(delta);
 
-            return connection.ExecuteAsync("INSERT INTO review.Audit (Action, ApplicationId, UserId, ChangedAt, ChangeDelta) VALUES (@action, @applicationId, @userId, @changedAt, @changeDelta)",
-                new {action, applicationId, userId, changedAt, changeDelta }, transaction);
+            return connection.ExecuteAsync("INSERT INTO review.Audit (ApplicationId, UserId, ChangedAt, Action, DataType, Data) VALUES (@applicationId, @userId, @changedAt, @action, @dataType, @data)",
+                new {applicationId, userId, changedAt, action, dataType, data }, transaction);
+        }
+
+        private string GetAuditDataTypeName(object data)
+        {
+            var type = data.GetType();
+
+            if(type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(List<>)))
+            {
+                var genericArgs = type.GetGenericArguments();
+                if (genericArgs.Any())
+                    return genericArgs[0].Name;
+            }
+
+            return type.Name;
         }
     }
 }

--- a/src/SFA.DAS.ApplyService.Database/SFA.DAS.ApplyService.Database.sqlproj
+++ b/src/SFA.DAS.ApplyService.Database/SFA.DAS.ApplyService.Database.sqlproj
@@ -83,6 +83,7 @@
     <Build Include="Tables\ApplicationWorkflow.sql" />
     <Build Include="review\Tables\Gateway.sql" />
     <Build Include="Security\review.sql" />
+    <Build Include="review\Tables\Audit.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Script.PostDeployment1.sql" />

--- a/src/SFA.DAS.ApplyService.Database/SFA.DAS.ApplyService.Database.sqlproj
+++ b/src/SFA.DAS.ApplyService.Database/SFA.DAS.ApplyService.Database.sqlproj
@@ -23,6 +23,7 @@
     <SqlServerVerification>False</SqlServerVerification>
     <IncludeCompositeObjects>True</IncludeCompositeObjects>
     <TargetDatabaseSet>True</TargetDatabaseSet>
+    <IncludeSchemaNameInFileName>False</IncludeSchemaNameInFileName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release\</OutputPath>
@@ -60,6 +61,9 @@
     <Folder Include="Tables\" />
     <Folder Include="StoredProcedures" />
     <Folder Include="Sequences" />
+    <Folder Include="review\" />
+    <Folder Include="review\Tables\" />
+    <Folder Include="Security\" />
   </ItemGroup>
   <ItemGroup>
     <Build Include="Tables\Assets.sql" />
@@ -77,11 +81,16 @@
     <Build Include="StoredProcedures\Update_ApplicationSections_QuestionTags.sql" />
     <Build Include="Sequences\AppRefSequence.sql" />
     <Build Include="Tables\ApplicationWorkflow.sql" />
+    <Build Include="review\Tables\Gateway.sql" />
+    <Build Include="Security\review.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Script.PostDeployment1.sql" />
   </ItemGroup>
   <ItemGroup>
     <PreDeploy Include="Script.PreDeployment1.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="SFA.DAS.ApplyService.Database.publish.xml" />
   </ItemGroup>
 </Project>

--- a/src/SFA.DAS.ApplyService.Database/Security/review.sql
+++ b/src/SFA.DAS.ApplyService.Database/Security/review.sql
@@ -1,0 +1,1 @@
+﻿CREATE SCHEMA [review]

--- a/src/SFA.DAS.ApplyService.Database/review/Tables/Audit.sql
+++ b/src/SFA.DAS.ApplyService.Database/review/Tables/Audit.sql
@@ -1,0 +1,13 @@
+﻿CREATE TABLE [review].[Audit](
+ [Id] [bigint] IDENTITY(1,1) NOT NULL,
+ [Action] NVARCHAR(50) NOT NULL,
+ [ApplicationId] [uniqueidentifier] NOT NULL,
+ [UserId] [nvarchar](100) NOT NULL,
+ [ChangedAt] [datetime2](7) NOT NULL,
+ [ChangeDelta] [nvarchar](max) NOT NULL,
+ CONSTRAINT [PK_Audit] PRIMARY KEY CLUSTERED 
+(
+	[Id] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO

--- a/src/SFA.DAS.ApplyService.Database/review/Tables/Audit.sql
+++ b/src/SFA.DAS.ApplyService.Database/review/Tables/Audit.sql
@@ -1,11 +1,12 @@
 ﻿CREATE TABLE [review].[Audit](
  [Id] [bigint] IDENTITY(1,1) NOT NULL,
- [Action] NVARCHAR(50) NOT NULL,
  [ApplicationId] [uniqueidentifier] NOT NULL,
  [UserId] [nvarchar](100) NOT NULL,
  [ChangedAt] [datetime2](7) NOT NULL,
- [ChangeDelta] [nvarchar](max) NOT NULL,
- CONSTRAINT [PK_Audit] PRIMARY KEY CLUSTERED 
+ [Action] NVARCHAR(50) NOT NULL,
+ [DataType] NVARCHAR(50) NOT NULL, 
+ [Data] NVARCHAR(MAX) NOT NULL
+    CONSTRAINT [PK_Audit] PRIMARY KEY CLUSTERED 
 (
 	[Id] ASC
 )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]

--- a/src/SFA.DAS.ApplyService.Database/review/Tables/Gateway.sql
+++ b/src/SFA.DAS.ApplyService.Database/review/Tables/Gateway.sql
@@ -1,8 +1,13 @@
 ﻿CREATE TABLE [review].[Gateway](
-	[Id] [uniqueidentifier] NOT NULL,
-	[ApplicationId] [uniqueidentifier] NOT NULL,
-	[Status] [nvarchar](20) NOT NULL,
- [Outcomes] NVARCHAR(MAX) NULL, 
+    [Id] UNIQUEIDENTIFIER NOT NULL,
+    [ApplicationId] UNIQUEIDENTIFIER NOT NULL,
+	[Status] NVARCHAR(20) NOT NULL,
+	[CreatedAt] DATETIME2 NOT NULL, 
+    [CreatedBy] NVARCHAR(256) NOT NULL, 
+    [AssignedAt] DATETIME2 NOT NULL, 
+    [AssignedTo] NVARCHAR(256) NOT NULL,
+	[AssignedToName] NVARCHAR(256) NOT NULL, 
+    [Outcomes] NVARCHAR(MAX) NULL,
     CONSTRAINT [PK_Gateway] PRIMARY KEY CLUSTERED 
 (
 	[Id] ASC

--- a/src/SFA.DAS.ApplyService.Database/review/Tables/Gateway.sql
+++ b/src/SFA.DAS.ApplyService.Database/review/Tables/Gateway.sql
@@ -1,0 +1,23 @@
+﻿CREATE TABLE [review].[Gateway](
+	[Id] [uniqueidentifier] NOT NULL,
+	[ApplicationId] [uniqueidentifier] NOT NULL,
+	[Status] [nvarchar](20) NOT NULL,
+ CONSTRAINT [PK_Gateway] PRIMARY KEY CLUSTERED 
+(
+	[Id] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+ALTER TABLE [review].[Gateway]  WITH CHECK ADD  CONSTRAINT [FK_Gateway_Applications] FOREIGN KEY([ApplicationId])
+REFERENCES [dbo].[Applications] ([Id])
+GO
+
+ALTER TABLE [review].[Gateway] CHECK CONSTRAINT [FK_Gateway_Applications]
+GO
+
+
+GO
+CREATE UNIQUE NONCLUSTERED INDEX [IX_Gateway] ON [review].[Gateway]
+(
+	[ApplicationId] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]

--- a/src/SFA.DAS.ApplyService.Database/review/Tables/Gateway.sql
+++ b/src/SFA.DAS.ApplyService.Database/review/Tables/Gateway.sql
@@ -2,7 +2,8 @@
 	[Id] [uniqueidentifier] NOT NULL,
 	[ApplicationId] [uniqueidentifier] NOT NULL,
 	[Status] [nvarchar](20) NOT NULL,
- CONSTRAINT [PK_Gateway] PRIMARY KEY CLUSTERED 
+ [Outcomes] NVARCHAR(MAX) NULL, 
+    CONSTRAINT [PK_Gateway] PRIMARY KEY CLUSTERED 
 (
 	[Id] ASC
 )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]

--- a/src/SFA.DAS.ApplyService.Domain/Entities/Review/Gateway.cs
+++ b/src/SFA.DAS.ApplyService.Domain/Entities/Review/Gateway.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace SFA.DAS.ApplyService.Domain.Entities.Review
+{
+    public class Gateway
+    {
+        public Guid Id { get; set; }
+        public Guid ApplicationId { get; set; }
+        public string Status { get; set; }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Domain/Entities/Review/Gateway.cs
+++ b/src/SFA.DAS.ApplyService.Domain/Entities/Review/Gateway.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using SFA.DAS.ApplyService.Domain.Review;
+using System;
+using System.Collections.Generic;
 
 namespace SFA.DAS.ApplyService.Domain.Entities.Review
 {
@@ -7,5 +9,6 @@ namespace SFA.DAS.ApplyService.Domain.Entities.Review
         public Guid Id { get; set; }
         public Guid ApplicationId { get; set; }
         public string Status { get; set; }
+        public List<Outcome> Outcomes { get; set; }
     }
 }

--- a/src/SFA.DAS.ApplyService.Domain/Review/Gateway/GatewayCounts.cs
+++ b/src/SFA.DAS.ApplyService.Domain/Review/Gateway/GatewayCounts.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.ApplyService.Domain.Review.Gateway
+{
+    public class GatewayCounts
+    {
+        public int NewApplications { get; set; }
+        public int InProgress { get; set; }
+    }
+}

--- a/src/SFA.DAS.ApplyService.Domain/Review/Outcome.cs
+++ b/src/SFA.DAS.ApplyService.Domain/Review/Outcome.cs
@@ -1,0 +1,13 @@
+﻿namespace SFA.DAS.ApplyService.Domain.Review
+{
+    public class Outcome
+    {
+        public string SectionId { get; set; }
+        public string PageId { get; set; }
+        public string QuestionId { get; set; }
+        public string Result { get; set; }
+        public string Message { get; set; }
+    }
+
+
+}

--- a/src/SFA.DAS.ApplyService.Domain/Review/Outcome.cs
+++ b/src/SFA.DAS.ApplyService.Domain/Review/Outcome.cs
@@ -1,13 +1,20 @@
-﻿namespace SFA.DAS.ApplyService.Domain.Review
+﻿using System.Collections.Generic;
+
+namespace SFA.DAS.ApplyService.Domain.Review
 {
     public class Outcome
     {
         public string SectionId { get; set; }
         public string PageId { get; set; }
         public string QuestionId { get; set; }
+        public List<Check> Checks { get; set; }
         public string Result { get; set; }
         public string Message { get; set; }
     }
 
-
+    public class Check
+    {
+        public string Name { get; set; }
+        public string Value { get; set; }
+    }
 }

--- a/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpAssessorController.cs
+++ b/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpAssessorController.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.ApplyService.Application.Review.GetGatewayCounts;
+using SFA.DAS.ApplyService.Application.Review.GetSubmittedApplications;
+using SFA.DAS.ApplyService.Domain.Review.Gateway;
+
+namespace SFA.DAS.ApplyService.InternalApi.Controllers
+{
+    [Authorize]
+    [Route("roatp-assessor")]
+    public class RoatpAssessorController : Controller
+    {
+        private readonly IMediator _mediator;
+
+        public RoatpAssessorController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet("applications/submitted")]
+        public async Task<ActionResult<List<Domain.Entities.Application>>> GetSubmittedApplications(Guid applicationId, string questionIdentifier)
+        {
+            return await _mediator.Send(new GetSubmittedApplicationsRequest());
+        }
+
+        [HttpGet("gateway/counts")]
+        public async Task<ActionResult<GatewayCounts>> GetGatewayCounts(Guid applicationId, string questionIdentifier)
+        {
+            return await _mediator.Send(new GetGatewayCountsRequest());
+        }
+    }
+}

--- a/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpAssessorController.cs
+++ b/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpAssessorController.cs
@@ -5,9 +5,11 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApplyService.Application.Review.GetGatewayCounts;
+using SFA.DAS.ApplyService.Application.Review.GetGatewayReview;
 using SFA.DAS.ApplyService.Application.Review.GetRejectedOutcomes;
 using SFA.DAS.ApplyService.Application.Review.GetSubmittedApplications;
 using SFA.DAS.ApplyService.Application.Review.UpdateGatewayOutcomes;
+using SFA.DAS.ApplyService.Domain.Entities.Review;
 using SFA.DAS.ApplyService.Domain.Review;
 using SFA.DAS.ApplyService.Domain.Review.Gateway;
 
@@ -48,6 +50,14 @@ namespace SFA.DAS.ApplyService.InternalApi.Controllers
         public async Task<ActionResult<List<Outcome>>> GetRejectedOutcomes([FromRoute] Guid applicationId, [FromRoute]string sectionId, [FromRoute]string pageId)
         {
             var request = new GetRejectedOutcomesRequest(applicationId, sectionId, pageId);
+
+            return await _mediator.Send(request);
+        }
+
+        [HttpGet("gateway/{applicationId:guid}")]
+        public async Task<ActionResult<Gateway>> GetGatewayReview([FromRoute] Guid applicationId)
+        {
+            var request = new GetGatewayReviewRequest(applicationId);
 
             return await _mediator.Send(request);
         }

--- a/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpAssessorController.cs
+++ b/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpAssessorController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApplyService.Application.Review.GetGatewayCounts;
 using SFA.DAS.ApplyService.Application.Review.GetSubmittedApplications;
+using SFA.DAS.ApplyService.Application.Review.UpdateGatewayOutcomes;
 using SFA.DAS.ApplyService.Domain.Review.Gateway;
 
 namespace SFA.DAS.ApplyService.InternalApi.Controllers
@@ -31,6 +32,14 @@ namespace SFA.DAS.ApplyService.InternalApi.Controllers
         public async Task<ActionResult<GatewayCounts>> GetGatewayCounts(Guid applicationId, string questionIdentifier)
         {
             return await _mediator.Send(new GetGatewayCountsRequest());
+        }
+
+        [HttpPost("gateway/outcomes")]
+        public async Task<ActionResult> PostGatewayOutcomes([FromBody] UpdateGatewayOutcomesCommand command)
+        {
+            await _mediator.Send(command);
+
+            return Ok();
         }
     }
 }

--- a/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpAssessorController.cs
+++ b/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpAssessorController.cs
@@ -4,7 +4,9 @@ using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.ApplyService.Application.Review.CreateGateway;
 using SFA.DAS.ApplyService.Application.Review.GetGatewayCounts;
+using SFA.DAS.ApplyService.Application.Review.GetGatewayInProgress;
 using SFA.DAS.ApplyService.Application.Review.GetGatewayReview;
 using SFA.DAS.ApplyService.Application.Review.GetRejectedOutcomes;
 using SFA.DAS.ApplyService.Application.Review.GetSubmittedApplications;
@@ -32,8 +34,22 @@ namespace SFA.DAS.ApplyService.InternalApi.Controllers
             return await _mediator.Send(new GetSubmittedApplicationsRequest());
         }
 
+        [HttpGet("gateway/in-progress")]
+        public async Task<ActionResult<List<Gateway>>> GetGatewayInProgress()
+        {
+            return await _mediator.Send(new GetGatewayInProgressRequest());
+        }
+
+        [HttpPost("gateway/create")]
+        public async Task<ActionResult> CreateGateway([FromBody] CreateGatewayRequest command)
+        {
+            await _mediator.Send(command);
+
+            return Ok();
+        }
+
         [HttpGet("gateway/counts")]
-        public async Task<ActionResult<GatewayCounts>> GetGatewayCounts(Guid applicationId, string questionIdentifier)
+        public async Task<ActionResult<GatewayCounts>> GetGatewayCounts()
         {
             return await _mediator.Send(new GetGatewayCountsRequest());
         }

--- a/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpAssessorController.cs
+++ b/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpAssessorController.cs
@@ -5,8 +5,10 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApplyService.Application.Review.GetGatewayCounts;
+using SFA.DAS.ApplyService.Application.Review.GetRejectedOutcomes;
 using SFA.DAS.ApplyService.Application.Review.GetSubmittedApplications;
 using SFA.DAS.ApplyService.Application.Review.UpdateGatewayOutcomes;
+using SFA.DAS.ApplyService.Domain.Review;
 using SFA.DAS.ApplyService.Domain.Review.Gateway;
 
 namespace SFA.DAS.ApplyService.InternalApi.Controllers
@@ -40,6 +42,14 @@ namespace SFA.DAS.ApplyService.InternalApi.Controllers
             await _mediator.Send(command);
 
             return Ok();
+        }
+
+        [HttpGet("review/rejected-outcomes/{applicationId:Guid}/{sectionId}/{pageId}")]
+        public async Task<ActionResult<List<Outcome>>> GetRejectedOutcomes([FromRoute] Guid applicationId, [FromRoute]string sectionId, [FromRoute]string pageId)
+        {
+            var request = new GetRejectedOutcomesRequest(applicationId, sectionId, pageId);
+
+            return await _mediator.Send(request);
         }
     }
 }

--- a/src/SFA.DAS.ApplyService.InternalApi/Startup.cs
+++ b/src/SFA.DAS.ApplyService.InternalApi/Startup.cs
@@ -29,6 +29,7 @@ using SFA.DAS.ApplyService.InternalApi.Infrastructure;
 
 namespace SFA.DAS.ApplyService.InternalApi
 {
+    using SFA.DAS.ApplyService.Application.Review;
     using UKRLP;
     using static UKRLP.ProviderQueryPortTypeClient;
 
@@ -193,6 +194,7 @@ namespace SFA.DAS.ApplyService.InternalApi
             services.AddTransient<IOrganisationRepository,OrganisationRepository>();
             services.AddTransient<IDfeSignInService,DfeSignInService>();
             services.AddTransient<IGetAnswersService, GetAnswersService>();
+            services.AddTransient<IReviewRepository, ReviewRepository>();
 
             services.AddTransient<IEmailService, EmailService.EmailService>();
             services.AddTransient<IEmailTemplateRepository, EmailTemplateRepository>();

--- a/src/SFA.DAS.ApplyService.InternalApi/appsettings.json
+++ b/src/SFA.DAS.ApplyService.InternalApi/appsettings.json
@@ -9,7 +9,7 @@
   },
   "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",
   "ConnectionStrings": {
-    "Redis": "localhost:234234234234"
+    "Redis": "localhost:6379"
   },
   "EnvironmentName": "LOCAL"
 }

--- a/src/SFA.DAS.ApplyService.Web/Controllers/PageViewModel.cs
+++ b/src/SFA.DAS.ApplyService.Web/Controllers/PageViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Internal;
 using SFA.DAS.ApplyService.Domain.Apply;
+using SFA.DAS.ApplyService.Domain.Review;
 using SFA.DAS.ApplyService.Web.Configuration;
 
 namespace SFA.DAS.ApplyService.Web.Controllers

--- a/src/SFA.DAS.ApplyService.Web/Controllers/Roatp/RoatpApplicationController.cs
+++ b/src/SFA.DAS.ApplyService.Web/Controllers/Roatp/RoatpApplicationController.cs
@@ -502,6 +502,8 @@ namespace SFA.DAS.ApplyService.Web.Controllers
                 ApplicationRouteId = providerRoute.Value
             };
 
+            ViewBag.RejectOutcomes = await _apiClient.GetRoatpAssessorRejectedOutcomesAsync(applicationId, preambleSection.Id, RoatpWorkflowPageIds.Preamble);
+
             return View("~/Views/Roatp/TaskList.cshtml", model);
         }
 

--- a/src/SFA.DAS.ApplyService.Web/Controllers/Roatp/RoatpApplicationController.cs
+++ b/src/SFA.DAS.ApplyService.Web/Controllers/Roatp/RoatpApplicationController.cs
@@ -335,6 +335,8 @@ namespace SFA.DAS.ApplyService.Web.Controllers
 
             viewModel = await TokeniseViewModelProperties(viewModel);
 
+            ViewBag.RejectOutcomes = await _apiClient.GetRoatpAssessorRejectedOutcomesAsync(applicationId, selectedSection.Id, pageId);
+
             if (viewModel.AllowMultipleAnswers)
             {
                 return View("~/Views/Application/Pages/MultipleAnswers.cshtml", viewModel);

--- a/src/SFA.DAS.ApplyService.Web/Infrastructure/ApplicationApiClient.cs
+++ b/src/SFA.DAS.ApplyService.Web/Infrastructure/ApplicationApiClient.cs
@@ -17,6 +17,7 @@ using StartApplicationResponse = SFA.DAS.ApplyService.Application.Apply.StartApp
 namespace SFA.DAS.ApplyService.Web.Infrastructure
 {
     using Application.Apply.GetAnswers;
+    using SFA.DAS.ApplyService.Domain.Review;
 
     public class ApplicationApiClient : IApplicationApiClient
     {
@@ -203,6 +204,12 @@ namespace SFA.DAS.ApplyService.Web.Infrastructure
         public async Task RemoveSectionCompleted(Guid applicationId, Guid applicationSectionId)
         {
             await _httpClient.DeleteAsync($"/Application/{applicationId}/RemoveSectionComplete/{applicationSectionId}");
+        }
+
+        public async Task<List<Outcome>> GetRoatpAssessorRejectedOutcomesAsync(Guid applicationId, Guid applicationSectionId, string pageId)
+        {
+            return await (await _httpClient.GetAsync($"/roatp-assessor/review/rejected-outcomes/{applicationId}/{applicationSectionId}/{pageId}"))
+                .Content.ReadAsAsync<List<Outcome>>();
         }
     }
 }

--- a/src/SFA.DAS.ApplyService.Web/Infrastructure/IApplicationApiClient.cs
+++ b/src/SFA.DAS.ApplyService.Web/Infrastructure/IApplicationApiClient.cs
@@ -14,6 +14,7 @@ using StartApplicationResponse = SFA.DAS.ApplyService.Application.Apply.StartApp
 namespace SFA.DAS.ApplyService.Web.Infrastructure
 {
     using Application.Apply.GetAnswers;
+    using SFA.DAS.ApplyService.Domain.Review;
 
     public interface IApplicationApiClient
     {
@@ -48,5 +49,7 @@ namespace SFA.DAS.ApplyService.Web.Infrastructure
         Task<bool> MarkSectionAsCompleted(Guid applicationId, Guid applicationSectionId);
         Task<bool> IsSectionCompleted(Guid applicationId, Guid applicationSectionId);
         Task RemoveSectionCompleted(Guid applicationId, Guid applicationSectionId);
+
+        Task<List<Outcome>> GetRoatpAssessorRejectedOutcomesAsync(Guid applicationId, Guid applicationSectionId, string pageId);
     }
 }

--- a/src/SFA.DAS.ApplyService.Web/Views/Application/Pages/Index.cshtml
+++ b/src/SFA.DAS.ApplyService.Web/Views/Application/Pages/Index.cshtml
@@ -108,6 +108,8 @@
                         {
                             foreach (var question in Model.Questions)
                             {
+                                <partial name="_RejectOutcome" model="question.QuestionId" />
+
                                 <div class="govuk-form-group @(!ViewData.ModelState.IsValid ? "govuk-form-group--error" : "")">
                                     <fieldset class="govuk-fieldset">
                                         @if (question.Type == "Checkbox" || question.Type == "Radio" || question.Type == "ComplexRadio" || question.Type == "CheckboxList")
@@ -187,6 +189,8 @@
                         {
                             foreach (var question in Model.Questions)
                             {
+                                <partial name="_RejectOutcome" model="question.QuestionId" />
+
                                 <div class="govuk-form-group @(question.ErrorMessages?.Any() ?? false ? "govuk-form-group--error" : "")">
 
                                     @if (question.Type == "Address")

--- a/src/SFA.DAS.ApplyService.Web/Views/Roatp/TaskList.cshtml
+++ b/src/SFA.DAS.ApplyService.Web/Views/Roatp/TaskList.cshtml
@@ -22,6 +22,9 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <h1 class="govuk-heading-l">Application overview</h1>
+
+                <partial name="_RejectOutcome" model="null"/>
+
                 <p class="govuk-body">Make sure you have read <a href="https://www.gov.uk/guidance/becoming-an-apprenticeship-training-provider" target="_blank">the becoming an apprenticeship training provider GOV.UK page (opens in a new window or tab)</a>.</p>
                 @*<p class="govuk-body">
                     UKPRN: @Model.UKPRN <br />

--- a/src/SFA.DAS.ApplyService.Web/Views/Shared/_RejectOutcome.cshtml
+++ b/src/SFA.DAS.ApplyService.Web/Views/Shared/_RejectOutcome.cshtml
@@ -3,7 +3,9 @@
 @model string
 
 @{ 
-    var questionRejectOutcomes = ((List<Outcome>)ViewBag.RejectOutcomes).Where(o => o.QuestionId == Model);
+    var questionRejectOutcomes = (string.IsNullOrEmpty(Model)) 
+        ? ((List<Outcome>)ViewBag.RejectOutcomes)
+        : ((List<Outcome>)ViewBag.RejectOutcomes).Where(o => o.QuestionId == Model);
 }
 
 @if (questionRejectOutcomes.Any())

--- a/src/SFA.DAS.ApplyService.Web/Views/Shared/_RejectOutcome.cshtml
+++ b/src/SFA.DAS.ApplyService.Web/Views/Shared/_RejectOutcome.cshtml
@@ -1,0 +1,18 @@
+﻿@using SFA.DAS.ApplyService.Domain.Review
+
+@model string
+
+@{ 
+    var questionRejectOutcomes = ((List<Outcome>)ViewBag.RejectOutcomes).Where(o => o.QuestionId == Model);
+}
+
+@if (questionRejectOutcomes.Any())
+{
+    <div class="govuk-inset-text">
+        <h2>Rejected answer</h2>
+        @foreach (var outcome in questionRejectOutcomes)
+        {
+            <p>@outcome.Message</p>
+        }
+    </div>
+}


### PR DESCRIPTION
**DO NOT MERGE - SPIKE**

Gateway Outcomes
============
Every question reviewed in Gateway has an 'outcome' of 'Pass', 'Reject' or 'In Progress'.  Each outcome is linked one-to-one to question in apply.  As well as these statuses each outcome can have many 'checks' associated with it.  These are boolean Yes/No questions.  So a question can have 3 checks but only one outcome.

Auditing
=====
Every change to the gateway review need to be audited.  I've added a Audit table to log these changes.

Added endpoints in Internal API
====================
- CreateGateway - Creates and assigns a gateway review and sets an application to `UnderReview` status
- GetGatewayInProgress - Returns all the gateway reviews that are currently with a state of `InProgress` ()used for the Gateway dashboard)
- GetGatewayReview - Returns a Gateway review
- GetRejectedOutcomes - returns a list of rejected outcomes - May be useful when displaying rejected applications in Apply.
- PostGatewayOutcomes - Updates the review with specified outcomes

Added Tables
=========
- review.Audit

Apply Web
=======
I've added an example of how we could surface Gateway Review Outcomes in the Apply Web.  This is pure speculation at this point 