### PR TITLE
QUAL-46 fix async and other compiler warnings

### DIFF
--- a/src/SFA.DAS.ApplyService.Data/OrganisationRepository.cs
+++ b/src/SFA.DAS.ApplyService.Data/OrganisationRepository.cs
@@ -94,9 +94,9 @@ namespace SFA.DAS.ApplyService.Data
             }
         }
 
-        private async Task UpdateOrganisation(Organisation organisation, SqlConnection connection)
+        private Task UpdateOrganisation(Organisation organisation, SqlConnection connection)
         {
-            connection.Execute(
+            return connection.ExecuteAsync(
                 "UPDATE [Organisations] " +
                 "SET [UpdatedAt] = GETUTCDATE(), [UpdatedBy] = @UpdatedBy, [Name] = @Name, " +
                 "[OrganisationType] = @OrganisationType, [OrganisationUKPRN] = @OrganisationUkprn, " +

--- a/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpApplicationController.cs
+++ b/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpApplicationController.cs
@@ -62,7 +62,7 @@
 
         [Route("roatp-sequences")]
         [HttpGet]
-        public async Task<IActionResult> RoatpSequences()
+        public IActionResult RoatpSequences()
         {
             return Ok(_roatpSequences);
         }

--- a/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpGatewayController.cs
+++ b/src/SFA.DAS.ApplyService.InternalApi/Controllers/RoatpGatewayController.cs
@@ -7,15 +7,11 @@ using Microsoft.Extensions.Logging;
 using SFA.DAS.ApplyService.Application.Apply;
 using SFA.DAS.ApplyService.Application.Apply.Gateway;
 using SFA.DAS.ApplyService.Domain.Entities;
-using SFA.DAS.ApplyService.InternalApi.Infrastructure;
 using SFA.DAS.ApplyService.InternalApi.Services;
 using SFA.DAS.ApplyService.InternalApi.Types;
 
 namespace SFA.DAS.ApplyService.InternalApi.Controllers
 {
-    /// <summary>
-    /// 
-    /// </summary>
     [Authorize]
     public class RoatpGatewayController: Controller
     {
@@ -23,10 +19,6 @@ namespace SFA.DAS.ApplyService.InternalApi.Controllers
         private readonly IGatewayApiChecksService _gatewayApiChecksService;
         private readonly ILogger<RoatpGatewayController> _logger;
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="applyRepository"></param>
         public RoatpGatewayController(IApplyRepository applyRepository, ILogger<RoatpGatewayController> logger,  IGatewayApiChecksService gatewayApiChecksService) 
         {
             _applyRepository = applyRepository;

--- a/src/SFA.DAS.ApplyService.InternalApi/SFA.DAS.ApplyService.InternalApi.csproj
+++ b/src/SFA.DAS.ApplyService.InternalApi/SFA.DAS.ApplyService.InternalApi.csproj
@@ -8,6 +8,7 @@
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
       <OutputPath>bin\Debug\netcoreapp2.2</OutputPath>
       <DocumentationFile>bin\Debug\netcoreapp2.2\SFA.DAS.ApplyService.InternalApi.xml</DocumentationFile>
+      <NoWarn>1701;1702; 1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/SFA.DAS.ApplyService.Web.UnitTests/Controllers/RoatpApplicationPreambleControllerTests.cs
+++ b/src/SFA.DAS.ApplyService.Web.UnitTests/Controllers/RoatpApplicationPreambleControllerTests.cs
@@ -1373,7 +1373,7 @@ namespace SFA.DAS.ApplyService.Web.UnitTests.Controllers
         {
             var model = new ConfirmChangeRouteViewModel { ApplicationId = Guid.NewGuid(), ConfirmChangeRoute = "Y" };
 
-            var result = _controller.SubmitConfirmChangeRoute(model).GetAwaiter().GetResult();
+            var result = _controller.SubmitConfirmChangeRoute(model);
 
             var redirectResult = result as RedirectToActionResult;
             redirectResult.Should().NotBeNull();
@@ -1385,7 +1385,7 @@ namespace SFA.DAS.ApplyService.Web.UnitTests.Controllers
         {
             var model = new ConfirmChangeRouteViewModel { ApplicationId = Guid.NewGuid(), ConfirmChangeRoute = "N" };
 
-            var result = _controller.SubmitConfirmChangeRoute(model).GetAwaiter().GetResult();
+            var result = _controller.SubmitConfirmChangeRoute(model);
 
             var redirectResult = result as RedirectToActionResult;
             redirectResult.Should().NotBeNull();

--- a/src/SFA.DAS.ApplyService.Web/Controllers/Roatp/RoatpApplicationController.cs
+++ b/src/SFA.DAS.ApplyService.Web/Controllers/Roatp/RoatpApplicationController.cs
@@ -1227,7 +1227,7 @@ namespace SFA.DAS.ApplyService.Web.Controllers
                     var applySection = sequence.Sections.FirstOrDefault(x => x.SectionNo == section.SectionId);
                     if (applySection != null)
                     {
-                        applySection.NotRequired = await SectionNotRequired(applicationSequence, _notRequiredOverrides, section.SectionId, roatpSequences);
+                        applySection.NotRequired = SectionNotRequired(applicationSequence, _notRequiredOverrides, section.SectionId, roatpSequences);
                     }
                 }
 
@@ -1411,8 +1411,7 @@ namespace SFA.DAS.ApplyService.Web.Controllers
             return (sectionCount == notRequiredCount);
         }
 
-        private async Task<bool> SectionNotRequired(ApplicationSequence sequence, List<NotRequiredOverrideConfiguration> notRequiredOverrides,
-                                                    int sectionId, IEnumerable<RoatpSequences> roatpSequences)
+        private bool SectionNotRequired(ApplicationSequence sequence, List<NotRequiredOverrideConfiguration> notRequiredOverrides, int sectionId, IEnumerable<RoatpSequences> roatpSequences)
         {
             var sequences = new List<ApplicationSequence>
             {

--- a/src/SFA.DAS.ApplyService.Web/Controllers/Roatp/RoatpApplicationPreambleController.cs
+++ b/src/SFA.DAS.ApplyService.Web/Controllers/Roatp/RoatpApplicationPreambleController.cs
@@ -519,7 +519,7 @@
         }
 
         [HttpGet]
-        public async Task<IActionResult> ConfirmChangeRoute(Guid applicationId)
+        public IActionResult ConfirmChangeRoute(Guid applicationId)
         {
             var model = new ConfirmChangeRouteViewModel { ApplicationId = applicationId };
             PopulateGetHelpWithQuestion(model, "ConfirmChangeRoute");
@@ -527,7 +527,7 @@
         }
 
         [HttpPost]
-        public async Task<IActionResult> SubmitConfirmChangeRoute(ConfirmChangeRouteViewModel model)
+        public IActionResult SubmitConfirmChangeRoute(ConfirmChangeRouteViewModel model)
         {
             if (!ModelState.IsValid)
             {
@@ -690,7 +690,7 @@
 
         [Route("change-ukprn")]
         [HttpGet]
-        public async Task<IActionResult> ChangeUkprn(Guid applicationId)
+        public IActionResult ChangeUkprn(Guid applicationId)
         {
             var model = new ChangeUkprnViewModel { ApplicationId = applicationId };
 

--- a/src/SFA.DAS.ApplyService.Web/Controllers/Roatp/RoatpShutterPagesController.cs
+++ b/src/SFA.DAS.ApplyService.Web/Controllers/Roatp/RoatpShutterPagesController.cs
@@ -20,13 +20,13 @@ namespace SFA.DAS.ApplyService.Web.Controllers.Roatp
         }
         
         [Route("not-accept-terms-conditions")]
-        public async Task<IActionResult> TermsAndConditionsNotAgreed(ConditionsOfAcceptanceViewModel model)
+        public IActionResult TermsAndConditionsNotAgreed(ConditionsOfAcceptanceViewModel model)
         {
             return View("~/Views/Roatp/TermsAndConditionsNotAgreed.cshtml", model);
         }
 
         [Route("uk-provider-reference-number-not-found")]
-        public async Task<IActionResult> UkprnNotFound()
+        public IActionResult UkprnNotFound()
         {
             var applicationDetails = _sessionService.Get<ApplicationDetails>(ApplicationDetailsKey);
 
@@ -39,7 +39,7 @@ namespace SFA.DAS.ApplyService.Web.Controllers.Roatp
         }
 
         [Route("company-not-found")]
-        public async Task<IActionResult> CompanyNotFound()
+        public IActionResult CompanyNotFound()
         {
             var applicationDetails = _sessionService.Get<ApplicationDetails>(ApplicationDetailsKey);
 
@@ -53,7 +53,7 @@ namespace SFA.DAS.ApplyService.Web.Controllers.Roatp
         }
 
         [Route("charity-not-found")]
-        public async Task<IActionResult> CharityNotFound()
+        public IActionResult CharityNotFound()
         {
             var applicationDetails = _sessionService.Get<ApplicationDetails>(ApplicationDetailsKey);
 
@@ -67,37 +67,37 @@ namespace SFA.DAS.ApplyService.Web.Controllers.Roatp
         }
 
         [Route("chosen-not-apply-roatp")]
-        public async Task<IActionResult> NonLevyAbandonedApplication()
+        public IActionResult NonLevyAbandonedApplication()
         {
             return View("~/Views/Roatp/NonLevyAbandonedApplication.cshtml");
         }
 
         [Route("ukrlp-unavailable")]
-        public async Task<IActionResult> UkrlpNotAvailable()
+        public IActionResult UkrlpNotAvailable()
         {
             return View("~/Views/Roatp/UkrlpNotAvailable.cshtml");
         }
 
         [Route("companies-house-unavailable")]
-        public async Task<IActionResult> CompaniesHouseNotAvailable()
+        public IActionResult CompaniesHouseNotAvailable()
         {
             return View("~/Views/Roatp/CompaniesHouseNotAvailable.cshtml");
         }
 
         [Route("charity-commission-unavailable")]
-        public async Task<IActionResult> CharityCommissionNotAvailable()
+        public IActionResult CharityCommissionNotAvailable()
         {
             return View("~/Views/Roatp/CharityCommissionNotAvailable.cshtml");
         }
 
         [Route("application-in-progress")]
-        public async Task<IActionResult> ApplicationInProgress(ExistingApplicationViewModel model)
+        public IActionResult ApplicationInProgress(ExistingApplicationViewModel model)
         {
             return View("~/Views/Roatp/ApplicationInProgress.cshtml", model);
         }
 
         [Route("application-submitted")]
-        public async Task<IActionResult> ApplicationPreviouslySubmitted(ExistingApplicationViewModel model)
+        public IActionResult ApplicationPreviouslySubmitted(ExistingApplicationViewModel model)
         {
             return View("~/Views/Roatp/ApplicationPreviouslySubmitted.cshtml", model);
         }

--- a/src/SFA.DAS.ApplyService.Web/Controllers/Roatp/RoatpWhosInControlApplicationController.cs
+++ b/src/SFA.DAS.ApplyService.Web/Controllers/Roatp/RoatpWhosInControlApplicationController.cs
@@ -787,7 +787,7 @@ namespace SFA.DAS.ApplyService.Web.Controllers.Roatp
             return await RemoveItemFromPscsList(
                 model,
                 RoatpWorkflowPageIds.WhosInControl.AddPartners,
-                RoatpYourOrganisationQuestionIdConstants.AddPartners,                
+                RoatpYourOrganisationQuestionIdConstants.AddPartners,
                 RoatpWorkflowQuestionTags.AddPartners, 
                 "ConfirmPartners",
                 model.BackAction);
@@ -806,7 +806,7 @@ namespace SFA.DAS.ApplyService.Web.Controllers.Roatp
         }
 
         [HttpPost]
-        public async Task<IActionResult> CompletePeopleInControlSection(Guid applicationId)
+        public IActionResult CompletePeopleInControlSection(Guid applicationId)
         {
             // tech debt - this will be reworked by the changes to the QnA config JSON and method
             // for determining that application section completed is derived (APR-1008)

--- a/src/SFA.DAS.ApplyService.Web/Controllers/UsersController.cs
+++ b/src/SFA.DAS.ApplyService.Web/Controllers/UsersController.cs
@@ -84,7 +84,7 @@ namespace SFA.DAS.ApplyService.Web.Controllers
         }
         
         [HttpGet]
-        public async Task<IActionResult> SignOut()
+        public IActionResult SignOut()
         {
             _contextAccessor.HttpContext.Session.Clear();
             foreach (var cookie in _contextAccessor.HttpContext.Request.Cookies.Keys)
@@ -156,7 +156,7 @@ namespace SFA.DAS.ApplyService.Web.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> ConfirmExistingAccount(ExistingAccountViewModel model)
+        public IActionResult ConfirmExistingAccount(ExistingAccountViewModel model)
         {
             if (!ModelState.IsValid)
             {

--- a/src/SFA.DAS.ApplyService.Web/Infrastructure/QnaApiClient.cs
+++ b/src/SFA.DAS.ApplyService.Web/Infrastructure/QnaApiClient.cs
@@ -289,13 +289,13 @@ namespace SFA.DAS.ApplyService.Web.Infrastructure
             }
         }
 
-        public async Task<AddPageAnswerResponse> AddPageAnswerToMultipleAnswerPage(Guid applicationId, Guid sectionId, string pageId, List<Answer> answer)
+        public Task<AddPageAnswerResponse> AddPageAnswerToMultipleAnswerPage(Guid applicationId, Guid sectionId, string pageId, List<Answer> answer)
         {
             // Not used. May need in future. See how EPAO Assessor Service does it
             throw new NotImplementedException();
         }
 
-        public async Task<Page> RemovePageAnswerFromMultipleAnswerPage(Guid applicationId, Guid sectionId, string pageId, Guid answerId)
+        public Task<Page> RemovePageAnswerFromMultipleAnswerPage(Guid applicationId, Guid sectionId, string pageId, Guid answerId)
         {
             // Not used. May need in future. See how EPAO Assessor Service does it
             throw new NotImplementedException();

--- a/src/SFA.DAS.ApplyService.Web/Infrastructure/Services/ProcessPageFlowService.cs
+++ b/src/SFA.DAS.ApplyService.Web/Infrastructure/Services/ProcessPageFlowService.cs
@@ -1,11 +1,9 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using SFA.DAS.ApplyService.Application.Apply.Roatp;
-using SFA.DAS.ApplyService.Domain.Roatp;
 using SFA.DAS.ApplyService.Web.Configuration;
 using SFA.DAS.ApplyService.Web.Infrastructure.Interfaces;
 
@@ -23,16 +21,15 @@ namespace SFA.DAS.ApplyService.Web.Infrastructure.Services
             _configuration = _configuration = configuration.Value;
         }
 
-        public async Task<string> GetIntroductionPageIdForSequence(int sequenceId,
+        public Task<string> GetIntroductionPageIdForSequence(int sequenceId,
             int providerTypeId)
         {
             var sequenceDescription = _configuration.FirstOrDefault(x => x.Id == sequenceId);
 
-            return sequenceDescription?.StartupPages
+            return Task.FromResult(sequenceDescription?.StartupPages
                 .FirstOrDefault(x => x.ProviderTypeId == providerTypeId)
-                ?.PageId;
+                ?.PageId);
         }
-
 
         public async Task<int> GetApplicationProviderTypeId(Guid applicationId)
         {
@@ -40,6 +37,7 @@ namespace SFA.DAS.ApplyService.Web.Infrastructure.Services
           
             var providerTypeAnswer =
                 await _qnaApiClient.GetAnswerByTag(applicationId, RoatpWorkflowQuestionTags.ProviderRoute);
+
             if (providerTypeAnswer != null && !String.IsNullOrWhiteSpace(providerTypeAnswer.Value))
             {
                 int.TryParse(providerTypeAnswer.Value, out providerTypeId);

--- a/src/SFA.DAS.ApplyService.Web/Infrastructure/UserService.cs
+++ b/src/SFA.DAS.ApplyService.Web/Infrastructure/UserService.cs
@@ -23,7 +23,7 @@ namespace SFA.DAS.ApplyService.Web.Infrastructure
             _logger = logger;
         }
 
-        public async Task<string> GetClaim(string claimName)
+        public Task<string> GetClaim(string claimName)
         {
             // try to get claim.
             var claim = _contextAccessor.HttpContext.User.FindFirst(claimName);
@@ -33,7 +33,7 @@ namespace SFA.DAS.ApplyService.Web.Infrastructure
                 throw new ArgumentException($"Claim {claimName} not found.");
             }
 
-            return claim.Value;
+            return Task.FromResult(claim.Value);
         }
 
         public async Task<bool> ValidateUser(string user)
@@ -134,7 +134,7 @@ namespace SFA.DAS.ApplyService.Web.Infrastructure
                 Guid.TryParse(value, out signInId);
 
             }
-            catch (ArgumentException e)
+            catch (ArgumentException)
             {
                 //Ignore should have beem already logged in getclaim
             }


### PR DESCRIPTION
I have updated the API project to ignore XML comments warnings as none of the controllers have XML comments. 
There are couple of warnings for unused variable left behind. I did not fix this as there is commented code that uses the variables and I do not have enough understanding to delete it. Also this is not in the scope of the task. 